### PR TITLE
Change time display from "二点" to "两点" for 2 o'clock

### DIFF
--- a/resources-zho/strings.xml
+++ b/resources-zho/strings.xml
@@ -14,7 +14,7 @@
   <string id="min55">	快要	$2$了</string>
   <string id="noon">中午</string>
   <string id="hour1">一点</string>
-  <string id="hour2">二点</string>
+  <string id="hour2">两点</string>
   <string id="hour3">三点</string>
   <string id="hour4">四点</string>
   <string id="hour5">五点</string>


### PR DESCRIPTION
Updated the watch face code to use "两点" instead of "二点" when displaying 2 o'clock

- This change improves linguistic naturalness as "两点" is the more common expression when telling time in spoken Chinese
- "两" is conventionally used for quantities in time expressions rather than "二"
- This change makes the watch face more intuitive and aligned with users' everyday language

Supporting evidence:
1. Asking ChatGPT for language usage verification
![image](https://github.com/user-attachments/assets/2e7c4ba5-4f81-41b5-aca8-042607b104e6)
2. User suggestions for community feedback requesting this change
![4a13718231c9f508068eeede4de771f](https://github.com/user-attachments/assets/52c561ce-c9b7-442a-be8d-e72d9ff66de6)

