### PR TITLE
Fixed typo in Süd Tirolerisch min35

### DIFF
--- a/resources-sti/strings.xml
+++ b/resources-sti/strings.xml
@@ -7,7 +7,7 @@
   <string id="min20">zwanzig	noch	$1$</string>
   <string id="min25">bold	holbe	$2$</string>
   <string id="min30">holbe	$2$	</string>
-  <string id="min35">kutz noch	holbe	$2$</string>
+  <string id="min35">kurz noch	holbe	$2$</string>
   <string id="min40">zwanzig	vour	$2$</string>
   <string id="min45">viartl	vour	$2$</string>
   <string id="min50">zehn	vour	$2$</string>


### PR DESCRIPTION
Fixed typo in Süd Tirolerisch min35 ("kutz"). This typo was already fixed in the Google Docs Spreadsheet, but does appear in the currently released version.